### PR TITLE
fix: Build the Docker image without running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN mv ~/.local/share/coursier/bin/** /usr/local/bin
 # Copy project files
 COPY . .
 
-# Build project
-RUN sbt clean && \
-    sbt assembly
+# Clean and build without running tests
+RUN sbt "set assembly / test := {}" clean assembly
 
 # Rename jar file
 RUN mv target/scala-2.13/*.jar target/scala-2.13/bundle.jar


### PR DESCRIPTION
Includes: 

- Update the Dockerfile to fix the broken release pipeline. 