### PR TITLE
fix: Setup HTTP server in tests 

### DIFF
--- a/src/test/scala/files_metadata/CanReadFileTests.scala
+++ b/src/test/scala/files_metadata/CanReadFileTests.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import io.restassured.RestAssured.`given`
 import org.junit.runner.manipulation.Alphanumeric
 import org.junit.runner.OrderWith
+import org.junit.Before
 import org.junit.Test
 import org.scalatestplus.junit.JUnitSuite
 
@@ -144,10 +145,9 @@ class CanReadFileTests extends JUnitSuite {
     )
   }
 
-  @Test
-  def T0_setup(): Unit = {
-    // Setup routes and perform migrations
-    Main.main( Array() )
+  @Before
+  def startHttpServer(): Unit = {
+    FilesTestsUtils.StartHttpServer()
   }
 
   @Test

--- a/src/test/scala/files_metadata/FilesTestsUtils.scala
+++ b/src/test/scala/files_metadata/FilesTestsUtils.scala
@@ -2,11 +2,22 @@ package org.hawksatlanta.metadata
 package files_metadata
 
 import java.util
+import java.util.concurrent.atomic.AtomicBoolean
 
 import io.restassured.response.Response
 import io.restassured.RestAssured.`given`
 
 object FilesTestsUtils {
+  var wasHttpServerInitializationCalled: AtomicBoolean = new AtomicBoolean(
+    false
+  )
+
+  def StartHttpServer(): Unit = {
+    if (wasHttpServerInitializationCalled.compareAndSet( false, true )) {
+      Main.main( Array[String]() )
+    }
+  }
+
   def SaveFile( payload: util.HashMap[String, Any] ): Response = {
     `given`()
       .port( 8080 )

--- a/src/test/scala/files_metadata/SaveFileMetadataTests.scala
+++ b/src/test/scala/files_metadata/SaveFileMetadataTests.scala
@@ -4,9 +4,9 @@ package files_metadata
 import java.util
 import java.util.UUID
 
-import io.restassured.RestAssured.`given`
 import org.junit.runner.manipulation.Alphanumeric
 import org.junit.runner.OrderWith
+import org.junit.Before
 import org.junit.Test
 import org.scalatestplus.junit.JUnitSuite
 import shared.infrastructure.CommonValidator
@@ -42,6 +42,11 @@ object SaveFileTestsData {
 
 @OrderWith( classOf[Alphanumeric] )
 class SaveFileMetadataTests extends JUnitSuite {
+  @Before
+  def startHttpServer(): Unit = {
+    FilesTestsUtils.StartHttpServer()
+  }
+
   @Test
   // POST /api/v1/files/:user_uuid Success: Save file metadata
   def T1_SaveArchiveMetadataSuccess(): Unit = {

--- a/src/test/scala/files_metadata/ShareFileTests.scala
+++ b/src/test/scala/files_metadata/ShareFileTests.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 
 import org.junit.runner.manipulation.Alphanumeric
 import org.junit.runner.OrderWith
+import org.junit.Before
 import org.junit.Test
 import org.scalatestplus.junit.JUnitSuite
 
@@ -65,6 +66,11 @@ class ShareFileTests extends JUnitSuite {
       FilesTestsUtils.SaveFile( saveDirectoryPayload )
     ShareFileTestsData.savedDirectoryUUID =
       UUID.fromString( saveDirectoryResponse.jsonPath().get( "uuid" ) )
+  }
+
+  @Before
+  def startHttpServer(): Unit = {
+    FilesTestsUtils.StartHttpServer()
   }
 
   @Test


### PR DESCRIPTION
Includes: 

- The server is now initialized without caring about the tests execution order. 