### PR TITLE
fix: Ignore ready state validations for directories

### DIFF
--- a/src/main/scala/files_metadata/application/FilesMetaUseCases.scala
+++ b/src/main/scala/files_metadata/application/FilesMetaUseCases.scala
@@ -92,22 +92,23 @@ class FilesMetaUseCases {
   def updateSavedFile( fileUUID: UUID, volume: String ): Unit = {
     val fileMetadata = repository.getFileMeta( fileUUID )
 
+    // Skip if the file is a directory
+    val fileIsDirectory = fileMetadata.archiveUuid.isEmpty
+    if (fileIsDirectory) {
+      throw DomainExceptions.FileAlreadyMarkedAsReadyException(
+        "Directories cannot be marked as ready"
+      )
+    }
+
+    // Skip if the file is already marked as ready
     if (fileMetadata.volume != null) {
       throw DomainExceptions.FileAlreadyMarkedAsReadyException(
         "The file was already marked as ready"
       )
     }
 
-    // If the file is an archive, update the archive status
-    if (fileMetadata.archiveUuid.isDefined) {
-      val archiveMetadata =
-        repository.getArchiveMeta( fileMetadata.archiveUuid.get )
-
-      repository.updateArchiveStatus( archiveMetadata.uuid, ready = true )
-    }
-
-    // Update the file volume
-    repository.updateFileVolume( fileUUID, volume )
+    // Update the status and volume
+    repository.updateArchiveToReady( fileMetadata, volume )
   }
 
   def getFileMetadata( fileUUID: UUID ): FileMeta = {

--- a/src/main/scala/files_metadata/domain/FilesMetaRepository.scala
+++ b/src/main/scala/files_metadata/domain/FilesMetaRepository.scala
@@ -41,9 +41,7 @@ trait FilesMetaRepository {
   def canUserReadFile( userUuid: UUID, fileUuid: UUID ): Boolean
 
   // --- Update ---
-  def updateArchiveStatus( archiveUUID: UUID, ready: Boolean ): Unit
-
-  def updateFileVolume( fileUUID: UUID, volume: String ): Unit
+  def updateArchiveToReady( file: FileMeta, volume: String ): Unit
 
   def updateFileName( fileUUID: UUID, newName: String ): Unit
 

--- a/src/main/scala/files_metadata/infrastructure/FilesMetaPostgresRepository.scala
+++ b/src/main/scala/files_metadata/infrastructure/FilesMetaPostgresRepository.scala
@@ -202,7 +202,10 @@ class FilesMetaPostgresRepository extends FilesMetaRepository {
           |uuid IN (
           | SELECT file_uuid FROM shared_files WHERE user_uuid = ?
           |)
-          |AND volume IS NOT NULL
+          |AND (
+          | archive_uuid is NULL
+          | OR volume IS NOT NULL
+          |)
           | """.stripMargin
       )
       statement.setObject( 1, userUuid )

--- a/src/main/scala/files_metadata/infrastructure/MetadataControllers.scala
+++ b/src/main/scala/files_metadata/infrastructure/MetadataControllers.scala
@@ -61,8 +61,8 @@ class MetadataControllers {
   }
 
   def SaveMetadataController(
-                              request: cask.Request
-                            ): cask.Response[Obj] = {
+      request: cask.Request
+  ): cask.Response[Obj] = {
     try {
       // Decode the JSON payload
       val decoded: CreationReqSchema = read[CreationReqSchema](
@@ -142,10 +142,10 @@ class MetadataControllers {
   }
 
   def ShareFileController(
-                           request: cask.Request,
-                           ownerUUID: String,
-                           fileUUID: String
-                         ): cask.Response[Obj] = {
+      request: cask.Request,
+      ownerUUID: String,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val decoded: ShareReqSchema = read[ShareReqSchema](
         request.text()
@@ -185,10 +185,10 @@ class MetadataControllers {
   }
 
   def CanReadFileController(
-                             request: cask.Request,
-                             userUUID: String,
-                             fileUUID: String
-                           ): cask.Response[Obj] = {
+      request: cask.Request,
+      userUUID: String,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isUserUUIDValid = CommonValidator.validateUUID( userUUID )
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
@@ -224,9 +224,9 @@ class MetadataControllers {
   }
 
   def GetFileMetadataController(
-                                 request: cask.Request,
-                                 fileUUID: String
-                               ): cask.Response[Obj] = {
+      request: cask.Request,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
       if (!isFileUUIDValid) {
@@ -243,7 +243,9 @@ class MetadataControllers {
         fileUUID = UUID.fromString( fileUUID )
       )
 
-      if (fileMeta.volume == null) {
+      val isFile      = fileMeta.archiveUuid.isDefined
+      val notSavedYet = fileMeta.volume == null
+      if (isFile && notSavedYet) {
         return cask.Response(
           ujson.Obj(
             "message" -> "The file is not ready yet"
@@ -256,12 +258,12 @@ class MetadataControllers {
         // Directories metadata
         cask.Response(
           ujson.Obj(
-            "archiveUUID" -> ujson.Null, // Needs to be a "custom" null value
             "name"        -> fileMeta.name,
+            "is_shared"   -> fileMeta.isShared,
+            "archiveUUID" -> ujson.Null,
             "extension"   -> ujson.Null,
-            "volume"      -> fileMeta.volume,
-            "size"        -> 0,
-            "is_shared"   -> fileMeta.isShared
+            "volume"      -> ujson.Null,
+            "size"        -> 0
           ),
           statusCode = 200
         )
@@ -289,9 +291,9 @@ class MetadataControllers {
   }
 
   def MarkFileAsReadyController(
-                                 request: cask.Request,
-                                 fileUUID: String
-                               ): cask.Response[Obj] = {
+      request: cask.Request,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
       if (!isFileUUIDValid) {
@@ -338,9 +340,9 @@ class MetadataControllers {
   }
 
   def GetSharedWithMeController(
-                                 request: cask.Request,
-                                 userUUID: String
-                               ): cask.Response[Obj] = {
+      request: cask.Request,
+      userUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isUserUUIDValid = CommonValidator.validateUUID( userUUID )
       if (!isUserUUIDValid) {
@@ -390,9 +392,9 @@ class MetadataControllers {
   }
 
   def GetSharedWithWhoController(
-                                  request: cask.Request,
-                                  fileUUID: String
-                                ): cask.Response[Obj] = {
+      request: cask.Request,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
       if (!isFileUUIDValid) {
@@ -425,10 +427,10 @@ class MetadataControllers {
   }
 
   def RenameFileController(
-                            request: cask.Request,
-                            userUUID: String,
-                            fileUUID: String
-                          ): cask.Response[Obj] = {
+      request: cask.Request,
+      userUUID: String,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
       val isUserUUIDValid = CommonValidator.validateUUID( userUUID )
@@ -477,10 +479,10 @@ class MetadataControllers {
   }
 
   def MoveFileController(
-                          request: cask.Request,
-                          userUUID: String,
-                          fileUUID: String
-                        ): cask.Response[Obj] = {
+      request: cask.Request,
+      userUUID: String,
+      fileUUID: String
+  ): cask.Response[Obj] = {
     try {
       val isFileUUIDValid = CommonValidator.validateUUID( fileUUID )
       val isUserUUIDValid = CommonValidator.validateUUID( userUUID )

--- a/src/test/scala/files_metadata/GetMetadata.scala
+++ b/src/test/scala/files_metadata/GetMetadata.scala
@@ -12,7 +12,7 @@ import org.scalatestplus.junit.JUnitSuite
 object GetFileMetadataTestsData {
   val API_PREFIX: String  = "/api/v1/files/metadata"
   val OWNER_UUID: UUID    = UUID.randomUUID()
-  val VOLUME_NAME: String = "volume_x"
+  val VOLUME_NAME: String = "1"
 
   var savedFileUUID: UUID      = _
   var savedDirectoryUUID: UUID = _
@@ -41,17 +41,12 @@ class GetFileMetadataTests extends JUnitSuite {
     )
   }
 
-  def markFilesAsReady(): Unit = {
+  def markFileAsReady(): Unit = {
     val updatePayload = new java.util.HashMap[String, Any]()
     updatePayload.put( "volume", GetFileMetadataTestsData.VOLUME_NAME )
 
     FilesTestsUtils.UpdateReadyFile(
       GetFileMetadataTestsData.savedFileUUID.toString,
-      updatePayload
-    )
-
-    FilesTestsUtils.UpdateReadyFile(
-      GetFileMetadataTestsData.savedDirectoryUUID.toString,
       updatePayload
     )
   }
@@ -84,7 +79,7 @@ class GetFileMetadataTests extends JUnitSuite {
 
   @Test
   def fileMetadataWithReadyFileUUID(): Unit = {
-    markFilesAsReady()
+    markFileAsReady()
 
     // Get the file
     val response = FilesTestsUtils.GetFileMetadata(
@@ -108,7 +103,7 @@ class GetFileMetadataTests extends JUnitSuite {
       directoryResponse
         .body()
         .jsonPath()
-        .getString( "volume" ) == GetFileMetadataTestsData.VOLUME_NAME
+        .getString( "volume" ) == null
     )
     assert(
       directoryResponse

--- a/src/test/scala/files_metadata/SharedWithMe.scala
+++ b/src/test/scala/files_metadata/SharedWithMe.scala
@@ -40,12 +40,7 @@ class GetSharedWithUser extends JUnitSuite {
     GetShareWithUserTestsData.savedFileUUID =
       UUID.fromString( saveFileResponse.jsonPath().get( "uuid" ) )
 
-    // Mark the file and the directory as ready
-    FilesTestsUtils.UpdateReadyFile(
-      GetShareWithUserTestsData.savedDirectoryUUID.toString,
-      FilesTestsUtils.generateReadyFilePayload()
-    )
-
+    // Mark the file as ready
     FilesTestsUtils.UpdateReadyFile(
       GetShareWithUserTestsData.savedFileUUID.toString,
       FilesTestsUtils.generateReadyFilePayload()

--- a/src/test/scala/files_metadata/UpdateToReady.scala
+++ b/src/test/scala/files_metadata/UpdateToReady.scala
@@ -101,7 +101,7 @@ class UpdateReadyFile extends JUnitSuite {
       UpdateReadyFileTestsData.getPayloadCopy()
     )
 
-    assert( updateDirectoryResponse.statusCode() == 204 )
+    assert( updateDirectoryResponse.statusCode() == 409 )
   }
 
   @Test
@@ -113,13 +113,5 @@ class UpdateReadyFile extends JUnitSuite {
     )
 
     assert( updateFileResponse.statusCode() == 409 )
-
-    // Try to mark the directory as ready again
-    val updateDirectoryResponse = FilesTestsUtils.UpdateReadyFile(
-      UpdateReadyFileTestsData.savedDirectoryUUID.toString,
-      UpdateReadyFileTestsData.getPayloadCopy()
-    )
-
-    assert( updateDirectoryResponse.statusCode() == 409 )
   }
 }


### PR DESCRIPTION
Includes: 

- Update endpoint to get metadata to skip ready checks for directories
- Use a single query with a transaction to update the `volume` column in the `files` table and the `ready` column in the `archives` table. 
- Update query to get files shared with an user to skip ready checks for directories. 